### PR TITLE
Add additional tagging and security group support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ There is a separate config file for the script in either "/etc/docker-build-ami.
     # tmp_dir = /tmp
 
     # Name tag for host building AMI image
-    # host_tag = docker-build-ami
+    # host_tag = 'docker-build-ami'
 
     # Region
     # region = eu-west-1
@@ -31,11 +31,30 @@ There is a separate config file for the script in either "/etc/docker-build-ami.
     # Subnet ID
     # subnet_id = subnet-123abc45
 
+    # Security Groups
+    # security_group_ids = ["sg-1234", "sg-23456"]
+
+    # Host Tags - additional tags to add to EC2 host
+    # host_tags = [{"Key": "foo", "Value": "bar"}]
+
     # AWS access key id
     # aws_access_key_id = DFSDF3HGDF4SDSD1DDFF
 
     # AWS secret access key
-    # aws_secret_access_key = 3riljdsf5SDFSDvsdfds452sdSDFDfsdf44SDFdR
+    # aws_secret_access_key = 3riljdsf5SDFSDvsdfds452sdSDFDfsdf44SDFdRA
+
+    # Base image from which the output image is built
+    # image_id = ami-0df67e2624dedbae1
+
+    # EC2 user used to build instances (usually AMI dependent)
+    # image_user = ubuntu
+
+    # The AMI Name of the output image
+    # image_name = ubuntu-test
+
+    # Image Tags - tags to add to AMI
+    # image_tags = [{"Key": "foo", "Value": "bar"}]
+
 
 Usage
 =====

--- a/etc/docker-build-ami.conf
+++ b/etc/docker-build-ami.conf
@@ -15,8 +15,26 @@
 # Subnet ID
 # subnet_id = subnet-123abc45
 
+# Security Groups
+# security_group_ids = ["sg-1234", "sg-23456"]
+
+# Host Tags - additional tags to add to EC2 host
+# host_tags = [{"Key": "foo", "Value": "bar"}]
+
 # AWS access key id
 # aws_access_key_id = DFSDF3HGDF4SDSD1DDFF
 
 # AWS secret access key
-# aws_secret_access_key = 3riljdsf5SDFSDvsdfds452sdSDFDfsdf44SDFdR
+# aws_secret_access_key = 3riljdsf5SDFSDvsdfds452sdSDFDfsdf44SDFdRA
+
+# Base image from which the output image is built
+# image_id = ami-0df67e2624dedbae1
+
+# EC2 user used to build instances (usually AMI dependent)
+# image_user = ubuntu
+
+# The AMI Name of the output image
+# image_name = ubuntu-test
+
+# Image Tags - tags to add to AMI
+# image_tags = [{"Key": "foo", "Value": "bar"}]

--- a/scripts/docker-build-ami
+++ b/scripts/docker-build-ami
@@ -1,21 +1,24 @@
 #!/usr/bin/env python
 
 import argparse
-import configparser
-import logging
 import boto3
-import os
-from os.path import expanduser, join, isfile
-import time
-import socket
-from sys import stdout
-import paramiko
-import uuid
+import configparser
 import datetime
-import tarfile
 import glob
+import json
+import logging
+import os
+import paramiko
 import pipes
 import re
+import socket
+import tarfile
+import time
+import uuid
+
+from os.path import expanduser, join, isfile
+from sys import stdout
+
 
 class color:
     RED = '\033[31m'
@@ -161,7 +164,7 @@ logger.addHandler(console)
 
 # Get configuration
 config = configparser.ConfigParser()
- 
+
 # Set defaults
 config.add_section('main')
 config.set('main', 'host_tag', 'docker-build-ami')
@@ -174,6 +177,9 @@ config.set('main', 'image_id', 'ami-e4ff5c93')
 config.set('main', 'image_user', 'centos')
 config.set('main', 'aws_access_key_id', '')
 config.set('main', 'aws_secret_access_key', '')
+config.set('main', 'security_group_ids', '[]')
+config.set('main', 'host_tags', '[]')
+config.set('main', 'image_tags', '[]')
 
 # Load config
 cfile = None
@@ -226,6 +232,10 @@ if not aws_secret_access_key:
     logger.critical('You need to specify a AWS Secret Access Key')
     exit(1)
 
+security_group_ids = json.loads(config.get('main', 'security_group_ids'))
+host_tags = json.loads(config.get('main', 'host_tags'))
+image_tags = json.loads(config.get('main', 'image_tags'))
+
 host_tag = config.get('main', 'host_tag')
 tmp_dir = config.get('main', 'tmp_dir')
 key_name = str(uuid.uuid4())
@@ -244,19 +254,20 @@ except:
 key_pair = ec2.create_key_pair(KeyName=key_name)
 with open(key_path, 'w') as f:
     f.write(key_pair['KeyMaterial'])
-
+tags = host_tags + [
+  {'Key': 'Name', 'Value': host_tag},
+]
+tag_spec = [
+  {'ResourceType': 'instance', 'Tags': tags},
+  {'ResourceType': 'volume', 'Tags': tags},
+]
 reservation = ec2.run_instances(ImageId=ami_id, KeyName=key_name, InstanceType=instance_type, SubnetId=subnet_id, \
-    MinCount=1, MaxCount=1)
+    MinCount=1, MaxCount=1, TagSpecifications=tag_spec, SecurityGroupIds=security_group_ids)
 
 for r in ec2.describe_instances()['Reservations']:
     if r['ReservationId'] == reservation['ReservationId']:
         break
-
 instance = r['Instances'][0]
-tags = [
-  {'Key': 'Name', 'Value': host_tag},
-]
-ec2.create_tags(Resources = [instance['InstanceId']], Tags=tags)
 
 print('Instance: %s' % instance['InstanceId'])
 print('Instance IP: %s' % instance['PrivateIpAddress'])
@@ -311,6 +322,7 @@ os.remove(key_path)
 
 print(f'Create AMI from instance: {instance_obj.instance_id}')
 image_obj = instance_obj.create_image(Name=f'{image_name}-{datetime.datetime.now().strftime("%Y%m%d%H%M%S")}')
+ec2.create_tags(Resources = [image_obj.image_id], Tags=image_tags + [{'Key': 'Name', 'Value': image_name}])
 
 while image_obj.state == 'pending':
     stdout.write('.')

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ CLASSIFIERS = [
 
 setup(
     name             = 'docker-build-ami',
-    version          = '0.4.0',
+    version          = '0.5.0',
 
     description      = 'Build Amazon EC2 AMI image using a Dockerfile',
     long_description = open("README.rst").read(),


### PR DESCRIPTION
This merge request adds features that are useful in environments with security and tagging policies.

- It adds the ability to attach security groups to the instance that creates the image. This is useful when the default SG disallows ssh.
- It adds the ability to tag the EC2 instance and volume. This is useful when the AMI creation fails for any reason leaving these two things and AWS janitor scripts need to know what to do with the items.